### PR TITLE
Prevent panic when resizing on linux/vulkan

### DIFF
--- a/src/bin/part01-resizing.rs
+++ b/src/bin/part01-resizing.rs
@@ -317,9 +317,8 @@ fn main() {
 
         device.wait_for_fence(&frame_fence, !0);
 
-        match swapchain.present(&mut queue_group.queues[0], frame_index, &[]) {
-            Ok(_) => (),
-            Err(_) => continue,
+        if let Err(_) = swapchain.present(&mut queue_group.queues[0], frame_index, &[]) {
+            resizing = true;
         }
     }
 

--- a/src/bin/part01-resizing.rs
+++ b/src/bin/part01-resizing.rs
@@ -317,9 +317,10 @@ fn main() {
 
         device.wait_for_fence(&frame_fence, !0);
 
-        swapchain
-            .present(&mut queue_group.queues[0], frame_index, &[])
-            .expect("Present failed");
+        match swapchain.present(&mut queue_group.queues[0], frame_index, &[]) {
+            Ok(_) => (),
+            Err(_) => continue,
+        }
     }
 
     // Cleanup


### PR DESCRIPTION
Stop part01-resizing from panicking when resizing on Linux, hopefully fixing #1
Although I guess it changes the meaning of the `resizing` variable to mean `remake_swapchain`.
